### PR TITLE
further changes for puppet 4 compatibility, plus comments

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,7 @@
 #
 class heartbeat (
 	$authkey      = 'secure123',
+	$virtual      = '',
 	$nodes        = '',
 	$resources    = '',
 	$udpport      = 694,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,11 @@
 # [*autoFailback*]
 #   Activate/deactivate auto takeover for resources.
 #   Default is off.
+# [*logfile*]
+#   Specify a log location, either a facility (like syslog, default),
+#   or a filepath, like /var/log/heartbeat
+# [*virtual*]
+#   specify what type of virtual host, like openvzve
 #
 # === Example
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,20 +59,20 @@ class heartbeat (
 	file {
 		"/etc/ha.d/haresources":
 		         notify  => Service["heartbeat"],
-			 mode    => 0644,
+			 mode    => "0644",
 			 owner   => root,
 			 group   => root,
 			 content => template("heartbeat/etc/ha.d/haresources.erb"),
 			 require => Package["heartbeat"];
 		"/etc/ha.d/ha.cf":
 		         notify  => Service["heartbeat"],
-			 mode    => 0644,
+			 mode    => "0644",
 			 owner   => root,
 			 group   => root,
 			 content => template("heartbeat/etc/ha.d/ha.cf.erb"),
 			 require => Package["heartbeat"];
 		"/etc/ha.d/authkeys":
-			 mode    => 0600,
+			 mode    => "0600",
 			 owner   => root,
 			 group   => root,
 			 content => template("heartbeat/etc/ha.d/authkeys.erb"),

--- a/templates/etc/ha.d/ha.cf.erb
+++ b/templates/etc/ha.d/ha.cf.erb
@@ -7,7 +7,7 @@ logfile <%= scope.lookupvar('heartbeat::logfile') %>
 logfacility syslog
 <% end %>
 
-<% if virtual == 'openvzve' %>
+<% if scope.lookupvar('heartbeat::virtual') == 'openvzve' %>
 realtime off
 <% end %>
 crm off


### PR DESCRIPTION
Added the extra variable, as well as one missing variable (logfile and virtual) to the comments of init.pp.

The new version of puppet doesn't like to have mode => 0644, it has to be mode => "0644".  Also, the ha.cf.erb was referencing a variable "virtual" which was not defined, and the new puppet version complained.  I wrapped it in a lookup to the init.pp.